### PR TITLE
HTLM pretty printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,19 @@ import { toText } from 'very-small-parser/lib/html/toText';
 const hast = html.parse('<b>Hello</b> <i>world</i>!');
 const html = toText(hast); // '<b>Hello</b> <i>world</i>!'
 ```
+
+Specify tabulation size for indentation when pretty-printing:
+
+```js
+import { html } from 'very-small-parser';
+import { toText } from 'very-small-parser/lib/html/toText';
+
+const tab = '  ';
+const hast = html.parse('<div><b>Hello</b><i>world</i>!</div>', tab);
+const html = toText(hast);
+// <div>
+//   <b>Hello</b>
+//   <i>world</i>
+//   !
+// </div>
+```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Using ESM.sh:
 
 ```html
 <script type="module">
-  import { markdown } from "//esm.sh/very-small-parser";
+  import { markdown } from '//esm.sh/very-small-parser';
 
   const ast = markdown.block.parse('Hello __world__!');
   console.log(ast);
@@ -29,7 +29,7 @@ Using jsDelivr:
 
 ```html
 <script type="module">
-  import { markdown } from "//esm.run/very-small-parser";
+  import { markdown } from '//esm.run/very-small-parser';
 
   const ast = markdown.block.parse('Hello __world__!');
   console.log(ast);
@@ -45,10 +45,12 @@ npm install very-small-parser
 
 ## Reference
 
+### Markdown
+
 Parse Markdown document (block elements):
 
 ```js
-import { markdown } from "very-small-parser";
+import { markdown } from 'very-small-parser';
 
 const ast = markdown.block.parse('Hello __world__!');
 ```
@@ -68,10 +70,23 @@ is('Hello __world__!');     // true
 is('<b>Hello</b>!');        // false
 ```
 
-Parse HTML:
+
+### HTML
+
+Parse HTML to HAST (Hypertext Abstract Syntax Tree):
 
 ```js
-import { html } from "very-small-parser";
+import { html } from 'very-small-parser';
 
 const ast = html.parse('<b>Hello</b> <i>world</i>!');
+```
+
+Pretty-print HAST to HTML:
+
+```js
+import { html } from 'very-small-parser';
+import { toText } from 'very-small-parser/lib/html/toText';
+
+const hast = html.parse('<b>Hello</b> <i>world</i>!');
+const html = toText(hast); // '<b>Hello</b> <i>world</i>!'
 ```

--- a/src/html/__tests__/setup.ts
+++ b/src/html/__tests__/setup.ts
@@ -1,5 +1,5 @@
 import {html} from '..';
-import {THtmlToken} from '../types';
+import type {THtmlToken} from '../types';
 
 export const parse = (text: string): THtmlToken[] => {
   const ast = html.parse(text);

--- a/src/html/__tests__/setup.ts
+++ b/src/html/__tests__/setup.ts
@@ -1,7 +1,7 @@
 import {html} from '..';
-import type {IToken} from '../../types';
+import {THtmlToken} from '../types';
 
-export const parse = (text: string): IToken[] => {
+export const parse = (text: string): THtmlToken[] => {
   const ast = html.parse(text);
   // console.log(JSON.stringify(ast, null, 2));
   return ast;

--- a/src/html/__tests__/toText.spec.ts
+++ b/src/html/__tests__/toText.spec.ts
@@ -1,5 +1,5 @@
 import {toText} from '../toText';
-import {IElement} from '../types';
+import type {IElement} from '../types';
 import {parse} from './setup';
 
 describe('toText', () => {
@@ -59,9 +59,13 @@ describe('toText', () => {
     });
 
     test('nested nodes', () => {
-      const ast = parse('<div><b>bold</b> text</div><p>Hello world</p><blockquote><p>Hello <b><u>world</u></b><i>!!!</i></p></blockquote>');
+      const ast = parse(
+        '<div><b>bold</b> text</div><p>Hello world</p><blockquote><p>Hello <b><u>world</u></b><i>!!!</i></p></blockquote>',
+      );
       const text = toText(ast);
-      expect(text).toBe('<div><b>bold</b> text</div><p>Hello world</p><blockquote><p>Hello <b><u>world</u></b><i>!!!</i></p></blockquote>');
+      expect(text).toBe(
+        '<div><b>bold</b> text</div><p>Hello world</p><blockquote><p>Hello <b><u>world</u></b><i>!!!</i></p></blockquote>',
+      );
     });
   });
 
@@ -107,7 +111,7 @@ describe('toText', () => {
     test('can escape attribute values', () => {
       const ast = parse('<span class="test<a:not(asdf)&test">text</span>');
       const text = toText(ast);
-      expect(text).toBe('<span class=\"test&lt;a:not(asdf)&amp;test\">text</span>');
+      expect(text).toBe('<span class="test&lt;a:not(asdf)&amp;test">text</span>');
     });
   });
 
@@ -117,7 +121,7 @@ describe('toText', () => {
       const text = toText(ast, '  ');
       expect(text).toBe('<div>\n  <hr foo="bar" />\n  <span>text</span>\n</div>');
     });
-    
+
     test('can format HTML fragment with tabbing', () => {
       const ast = parse('<hr foo="bar" /><span>text</span>');
       const text = toText(ast, '  ');
@@ -129,7 +133,7 @@ describe('toText', () => {
       const text = toText(ast, '  ');
       expect(text).toBe('<div>\n  <b>Hello</b>\n  <i>world</i>\n  !\n</div>');
     });
-    
+
     test('can format HTML fragment with tabbing - 2', () => {
       const ast: IElement = {
         type: 'element',
@@ -153,11 +157,11 @@ describe('toText', () => {
                 tagName: 'span',
                 properties: {},
                 len: 0,
-                children: [{type: 'text', value: 'text'}]
+                children: [{type: 'text', value: 'text'}],
               } as IElement,
             ],
           },
-        ]
+        ],
       };
       const text = toText(ast, '  ');
       expect(text).toBe('<div>\n  <hr foo="bar" />\n  <span>text</span>\n</div>');

--- a/src/html/__tests__/toText.spec.ts
+++ b/src/html/__tests__/toText.spec.ts
@@ -1,0 +1,36 @@
+import {toText} from '../toText';
+import {parse} from './setup';
+
+describe('toText', () => {
+  describe('can pretty-print basic HTML', () => {
+    test('inline HTML', () => {
+      const ast = parse('<b>ab<i>c</i></b>');
+      const text = toText(ast);
+      expect(text).toBe('<b>ab<i>c</i></b>');
+    });
+
+    test('plain text', () => {
+      const ast = parse('hello world');
+      const text = toText(ast);
+      expect(text).toBe('hello world');
+    });
+
+    test('tag inside text', () => {
+      const ast = parse('hello <em>world</em>!');
+      const text = toText(ast);
+      expect(text).toBe('hello <em>world</em>!');
+    });
+
+    test('tag wrapping text', () => {
+      const ast = parse('<u>underline</u>');
+      const text = toText(ast);
+      expect(text).toBe('<u>underline</u>');
+    });
+
+    test('a single self-closing tag', () => {
+      const ast = parse('<br/>');
+      const text = toText(ast);
+      expect(text).toBe('<br />');
+    });
+  });
+});

--- a/src/html/__tests__/toText.spec.ts
+++ b/src/html/__tests__/toText.spec.ts
@@ -123,6 +123,12 @@ describe('toText', () => {
       const text = toText(ast, '  ');
       expect(text).toBe('<hr foo="bar" />\n<span>text</span>');
     });
+
+    test('can format HTML element with tabbing', () => {
+      const ast = parse('<div><b>Hello</b><i>world</i>!</div>');
+      const text = toText(ast, '  ');
+      expect(text).toBe('<div>\n  <b>Hello</b>\n  <i>world</i>\n  !\n</div>');
+    });
     
     test('can format HTML fragment with tabbing - 2', () => {
       const ast: IElement = {

--- a/src/html/__tests__/toText.spec.ts
+++ b/src/html/__tests__/toText.spec.ts
@@ -1,4 +1,5 @@
 import {toText} from '../toText';
+import {IElement} from '../types';
 import {parse} from './setup';
 
 describe('toText', () => {
@@ -27,10 +28,133 @@ describe('toText', () => {
       expect(text).toBe('<u>underline</u>');
     });
 
+    test('two tags wrapping each other', () => {
+      const ast = parse('<b><i>42</i></b>');
+      const text = toText(ast);
+      expect(text).toBe('<b><i>42</i></b>');
+    });
+
     test('a single self-closing tag', () => {
       const ast = parse('<br/>');
       const text = toText(ast);
       expect(text).toBe('<br />');
+    });
+
+    test('a single self-closing tag with whitespace', () => {
+      const ast = parse('<hr   />');
+      const text = toText(ast);
+      expect(text).toBe('<hr />');
+    });
+
+    test('a single self-closing tag with attributes', () => {
+      const ast = parse('<meta lang="js" />');
+      const text = toText(ast);
+      expect(text).toBe('<meta lang="js" />');
+    });
+
+    test('a single self-closing without closing slash', () => {
+      const ast = parse('<meta lang="js">');
+      const text = toText(ast);
+      expect(text).toBe('<meta lang="js" />');
+    });
+
+    test('nested nodes', () => {
+      const ast = parse('<div><b>bold</b> text</div><p>Hello world</p><blockquote><p>Hello <b><u>world</u></b><i>!!!</i></p></blockquote>');
+      const text = toText(ast);
+      expect(text).toBe('<div><b>bold</b> text</div><p>Hello world</p><blockquote><p>Hello <b><u>world</u></b><i>!!!</i></p></blockquote>');
+    });
+  });
+
+  describe('fragments', () => {
+    test('fragment: element + text', () => {
+      const ast = parse('<b>bold</b> text');
+      const text = toText(ast);
+      expect(text).toBe('<b>bold</b> text');
+    });
+
+    test('fragment: multiple elements', () => {
+      const ast = parse('<b>bold</b><i>italic</i><u>underline</u>');
+      const text = toText(ast);
+      expect(text).toBe('<b>bold</b><i>italic</i><u>underline</u>');
+    });
+
+    test('fragment: text + element + text', () => {
+      const ast = parse('a <b>b</b> c');
+      const text = toText(ast);
+      expect(text).toBe('a <b>b</b> c');
+    });
+  });
+
+  describe('escaping', () => {
+    test('can escape text nodes', () => {
+      const ast = parse('<div><b>bold</b> text >></div>');
+      const text = toText(ast);
+      expect(text).toBe('<div><b>bold</b> text &#62;&#62;</div>');
+    });
+
+    test('can escape plain text', () => {
+      const ast = parse('text >>');
+      const text = toText(ast);
+      expect(text).toBe('text &#62;&#62;');
+    });
+
+    test('can render attributes', () => {
+      const ast = parse('<div data-type="very-bold"><b>bold</b> text >></div>');
+      const text = toText(ast);
+      expect(text).toBe('<div data-type="very-bold"><b>bold</b> text &#62;&#62;</div>');
+    });
+
+    test('can escape attribute values', () => {
+      const ast = parse('<span class="test<a:not(asdf)&test">text</span>');
+      const text = toText(ast);
+      expect(text).toBe('<span class=\"test&lt;a:not(asdf)&amp;test\">text</span>');
+    });
+  });
+
+  describe('indentation', () => {
+    test('can format HTML with tabbing', () => {
+      const ast = parse('<div><hr foo="bar" /><span>text</span></div>');
+      const text = toText(ast, '  ');
+      expect(text).toBe('<div>\n  <hr foo="bar" />\n  <span>text</span>\n</div>');
+    });
+    
+    test('can format HTML fragment with tabbing', () => {
+      const ast = parse('<hr foo="bar" /><span>text</span>');
+      const text = toText(ast, '  ');
+      expect(text).toBe('<hr foo="bar" />\n<span>text</span>');
+    });
+    
+    test('can format HTML fragment with tabbing - 2', () => {
+      const ast: IElement = {
+        type: 'element',
+        tagName: 'div',
+        properties: {},
+        len: 0,
+        children: [
+          {
+            type: 'root',
+            len: 0,
+            children: [
+              {
+                type: 'element',
+                tagName: 'hr',
+                properties: {foo: 'bar'},
+                len: 0,
+                children: [],
+              } as IElement,
+              {
+                type: 'element',
+                tagName: 'span',
+                properties: {},
+                len: 0,
+                children: [{type: 'text', value: 'text'}]
+              } as IElement,
+            ],
+          },
+        ]
+      };
+      const text = toText(ast, '  ');
+      expect(text).toBe('<div>\n  <hr foo="bar" />\n  <span>text</span>\n</div>');
     });
   });
 });

--- a/src/html/toText.ts
+++ b/src/html/toText.ts
@@ -1,8 +1,10 @@
-import {THtmlToken} from "./types";
+import {THtmlToken, IElement, IRoot} from "./types";
 
 const escapeText = (str: string): string => str.replace(/[\u00A0-\u9999<>\&]/gim, (i) => '&#' + i.charCodeAt(0) + ';');
 
 const escapeAttr = (str: string): string => str.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
+
+const PROPS = {};
 
 /**
  * Pretty-prints an HTML node to text.
@@ -13,7 +15,10 @@ const escapeAttr = (str: string): string => str.replace(/&/g, '&amp;').replace(/
  * @returns Text representation of the HTML node
  */
 export const toText = (node: THtmlToken | THtmlToken[], tab: string = '', ident: string = ''): string => {
-  if (Array.isArray(node)) return node.map((n) => toText(n, tab, ident)).join('');
+  if (Array.isArray(node)) {
+    const root: IRoot = {type: 'root', len: 0, children: node};
+    return toText(root, tab, ident);
+  }
   if (typeof node === 'string') return ident + escapeText(node);
   const {type} = node;
   switch (type) {
@@ -24,8 +29,15 @@ export const toText = (node: THtmlToken | THtmlToken[], tab: string = '', ident:
       return value ? ident + '<!--' + escapeText(value) + '-->' : '';
     }
     // case 'doctype': return '';
+    case 'root':
     case 'element': {
-      const {tagName, properties, children} = node;
+      const children = node.children;
+      let tagName: IElement['tagName'] = '';
+      let properties: IElement['properties'] = PROPS;
+      if (type === 'element') {
+        tagName = node.tagName;
+        properties = node.properties;
+      }
       const childrenLength = children.length;
       const isFragment = !tagName;
       const childrenIdent = ident + (isFragment ? '' : tab);

--- a/src/html/toText.ts
+++ b/src/html/toText.ts
@@ -1,4 +1,4 @@
-import {THtmlToken, IElement, IRoot} from "./types";
+import type {THtmlToken, IElement, IRoot} from './types';
 
 const escapeText = (str: string): string => str.replace(/[\u00A0-\u9999<>\&]/gim, (i) => '&#' + i.charCodeAt(0) + ';');
 
@@ -55,7 +55,8 @@ export const toText = (node: THtmlToken | THtmlToken[], tab: string = '', ident:
           childrenStr += (doIdent ? (!isFragment || i ? '\n' : '') : '') + toText(children[i], tab, childrenIdent);
       if (isFragment) return childrenStr;
       let attrStr = '';
-      if (properties) for (const key in properties) attrStr += ' ' + key + '="' + escapeAttr(properties[key] + '') + '"';
+      if (properties)
+        for (const key in properties) attrStr += ' ' + key + '="' + escapeAttr(properties[key] + '') + '"';
       const htmlHead = '<' + tagName + attrStr;
       return (
         ident +

--- a/src/html/toText.ts
+++ b/src/html/toText.ts
@@ -1,0 +1,57 @@
+import {THtmlToken} from "./types";
+
+const escapeText = (str: string): string => str.replace(/[\u00A0-\u9999<>\&]/gim, (i) => '&#' + i.charCodeAt(0) + ';');
+
+const escapeAttr = (str: string): string => str.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
+
+/**
+ * Pretty-prints an HTML node to text.
+ *
+ * @param node HTML node to convert to text
+ * @param tab Tabulation for children
+ * @param ident Current indentation
+ * @returns Text representation of the HTML node
+ */
+export const toText = (node: THtmlToken | THtmlToken[], tab: string = '', ident: string = ''): string => {
+  if (Array.isArray(node)) return node.map((n) => toText(n, tab, ident)).join('');
+  if (typeof node === 'string') return ident + escapeText(node);
+  const {type} = node;
+  switch (type) {
+    case 'text':
+      return ident + escapeText(node.value || '');
+    case 'comment': {
+      const {value} = node;
+      return value ? ident + '<!--' + escapeText(value) + '-->' : '';
+    }
+    // case 'doctype': return '';
+    case 'element': {
+      const {tagName, properties, children} = node;
+      const childrenLength = children.length;
+      const isFragment = !tagName;
+      const childrenIdent = ident + (isFragment ? '' : tab);
+      const doIdent = !!tab;
+      let childrenStr = '';
+      let textOnlyChildren = true;
+      for (let i = 0; i < childrenLength; i++)
+        if (children[i].type !== 'text') {
+          textOnlyChildren = false;
+          break;
+        }
+      if (textOnlyChildren) for (let i = 0; i < childrenLength; i++) childrenStr += escapeText(children[i].value || '');
+      else
+        for (let i = 0; i < childrenLength; i++)
+          childrenStr += (doIdent ? (!isFragment || i ? '\n' : '') : '') + toText(children[i], tab, childrenIdent);
+      if (isFragment) return childrenStr;
+      let attrStr = '';
+      if (properties) for (const key in properties) attrStr += ' ' + key + '="' + escapeAttr(properties[key] + '') + '"';
+      const htmlHead = '<' + tagName + attrStr;
+      return (
+        ident +
+        (childrenStr
+          ? htmlHead + '>' + childrenStr + (doIdent && !textOnlyChildren ? '\n' + ident : '') + '</' + tagName + '>'
+          : htmlHead + ' />')
+      );
+    }
+  }
+  return '';
+};

--- a/src/html/types.ts
+++ b/src/html/types.ts
@@ -21,7 +21,7 @@ export interface IElement extends IToken {
   type: 'element';
   tagName: string;
   properties: Record<string, string>;
-  children: (IComment | IElement | IText)[];
+  children: (IComment | IElement | IText | IRoot)[];
 }
 
 export type THtmlToken = IRoot | IText | IComment | IDoctype | IElement;


### PR DESCRIPTION
Implements pretty-printing: HAST (HTML AST) to text:

## Usage

Pretty-print HAST to HTML:

```js
import { html } from 'very-small-parser';
import { toText } from 'very-small-parser/lib/html/toText';

const hast = html.parse('<b>Hello</b> <i>world</i>!');
const html = toText(hast); // '<b>Hello</b> <i>world</i>!'
```

Specify tabulation size for indentation when pretty-printing:

```js
import { html } from 'very-small-parser';
import { toText } from 'very-small-parser/lib/html/toText';

const tab = '  ';
const hast = html.parse('<div><b>Hello</b><i>world</i>!</div>', tab);
const html = toText(hast);
// <div>
//   <b>Hello</b>
//   <i>world</i>
//   !
// </div>
```
