### PR TITLE
Spoiler block elements

### DIFF
--- a/src/html/__tests__/toMdast.fixtures.ts
+++ b/src/html/__tests__/toMdast.fixtures.ts
@@ -43,6 +43,7 @@ export const testCases: [html: string, markdown: string, name?: string][] = [
   // Block elements
   ['<p>paragraph</p>', 'paragraph'],
   ['<blockquote>quote</blockquote>', '> quote'],
+  ['<blockquote data-spoiler="true">quote</blockquote>', '>! quote'],
   ['<blockquote><p>quote</p></blockquote>', '> quote'],
   ['<blockquote><p>paragraph 1</p><p>paragraph 2</p></blockquote>', '> paragraph 1\n> \n> paragraph 2'],
   ['<pre>code</pre>', '```\ncode\n```'],

--- a/src/html/toMdast.ts
+++ b/src/html/toMdast.ts
@@ -209,7 +209,7 @@ export const toMdast0 = (node: html.THtmlToken): IToken => {
   if (Array.isArray(node)) return toMdast0({type: 'root', children: node});
   switch (node.type) {
     case 'element': {
-      const {tagName} = node;
+      const {tagName, properties} = node;
       switch (tagName) {
         case 'p': {
           return {
@@ -218,14 +218,16 @@ export const toMdast0 = (node: html.THtmlToken): IToken => {
           };
         }
         case 'blockquote': {
-          return {
+          const blockquote: md.IBlockquote = {
             type: 'blockquote',
-            children: toMdastChildren(node) as mdi.TInlineToken[],
+            children: toMdastChildren(node) as md.TBlockToken[],
           };
+          if (properties?.['data-spoiler'] === 'true') blockquote.spoiler = true;
+          return blockquote;
         }
         case 'code':
         case 'pre': {
-          const attr = node.properties || {};
+          const attr = properties || {};
           const children = node.children || [];
           if (children.length) {
             const firstChild = node.children?.[0];
@@ -276,7 +278,7 @@ export const toMdast0 = (node: html.THtmlToken): IToken => {
             ordered,
             children: [],
           };
-          if (ordered) list.start = Number.parseInt(node.properties?.start || '1');
+          if (ordered) list.start = Number.parseInt(properties?.start || '1');
           for (let i = 0; i < length; i++) {
             const child = children[i];
             if (child.type !== 'element' || child.tagName !== 'li') continue;

--- a/src/markdown/block/__tests__/blockquote.spec.ts
+++ b/src/markdown/block/__tests__/blockquote.spec.ts
@@ -1,0 +1,49 @@
+import {parse} from './setup';
+
+describe('blockquote', () => {
+  test('single paragraph', () => {
+    const ast = parse('> paragraph');
+    expect(ast[0]).toMatchObject({
+      type: 'blockquote',
+      children: [
+        {type: 'paragraph', children: [{type: 'text', value: 'paragraph'}]},
+      ],
+    });
+  });
+
+  test('two paragraphs', () => {
+    const ast = parse('> item 1\n> \n> item 2');
+    expect(ast[0]).toMatchObject({
+      type: 'blockquote',
+      children: [
+        {type: 'paragraph', children: [{type: 'text', value: 'item 1'}]},
+        {type: 'paragraph', children: [{type: 'text', value: 'item 2'}]},
+      ],
+    });
+  });
+
+  describe('spoiler', () => {
+    test('single paragraph', () => {
+      const ast = parse('>! paragraph');
+      expect(ast[0]).toMatchObject({
+        type: 'blockquote',
+        spoiler: true,
+        children: [
+          {type: 'paragraph', children: [{type: 'text', value: 'paragraph'}]},
+        ],
+      });
+    });
+
+    test('two paragraphs', () => {
+      const ast = parse('>! item 1\n>! \n>     ! item 2');
+      expect(ast[0]).toMatchObject({
+        type: 'blockquote',
+        spoiler: true,
+        children: [
+          {type: 'paragraph', children: [{type: 'text', value: 'item 1'}]},
+          {type: 'paragraph', children: [{type: 'text', value: 'item 2'}]},
+        ],
+      });
+    });
+  });
+});

--- a/src/markdown/block/__tests__/blockquote.spec.ts
+++ b/src/markdown/block/__tests__/blockquote.spec.ts
@@ -5,9 +5,7 @@ describe('blockquote', () => {
     const ast = parse('> paragraph');
     expect(ast[0]).toMatchObject({
       type: 'blockquote',
-      children: [
-        {type: 'paragraph', children: [{type: 'text', value: 'paragraph'}]},
-      ],
+      children: [{type: 'paragraph', children: [{type: 'text', value: 'paragraph'}]}],
     });
   });
 
@@ -28,9 +26,7 @@ describe('blockquote', () => {
       expect(ast[0]).toMatchObject({
         type: 'blockquote',
         spoiler: true,
-        children: [
-          {type: 'paragraph', children: [{type: 'text', value: 'paragraph'}]},
-        ],
+        children: [{type: 'paragraph', children: [{type: 'text', value: 'paragraph'}]}],
       });
     });
 

--- a/src/markdown/block/__tests__/toHast.fixtures.ts
+++ b/src/markdown/block/__tests__/toHast.fixtures.ts
@@ -7,6 +7,7 @@ export const testCases: [markdown: string, html: string, name?: string][] = [
     'paragraph and blockquote',
   ],
   ['> this is blockquote', '<blockquote><p>this is blockquote</p></blockquote>'],
+  ['>! this is spoiler', '<blockquote data-spoiler="true"><p>this is spoiler</p></blockquote>'],
   ['# heading 1', '<h1>heading 1</h1>'],
   ['## heading 2', '<h2>heading 2</h2>'],
   ['### heading 3', '<h3>heading 3</h3>'],

--- a/src/markdown/block/__tests__/toText-block.spec.ts
+++ b/src/markdown/block/__tests__/toText-block.spec.ts
@@ -32,6 +32,8 @@ describe('toText', () => {
     ['> blockquote\n> with multiple lines', void 0, 'blockquote with multiple lines'],
     ['> blockquote\n> \n> with multiple blocks', void 0, 'blockquote with multiple blocks'],
     ['> blockquote\n> \n> ```\n> with multiple blocks\n> ```', void 0, 'blockquote with multiple blocks and code'],
+    ['>! spoiler', void 0, 'simple blockquote'],
+    ['>! spoiler\n>! with multiple lines', void 0, 'blockquote with multiple lines'],
     ['- single list item'],
     ['- first\n- second', void 0, 'multiple list items'],
     ['- first\n\n- second', '- first\n\n- second', 'multiple *loose* list items'],

--- a/src/markdown/block/toHast.ts
+++ b/src/markdown/block/toHast.ts
@@ -70,7 +70,9 @@ export const toHast = (node: IToken | IToken[]): hast.THtmlToken => {
     case 'heading':
       return element('h' + block.depth, block, void 0, toTextChildrenInline(block));
     case 'blockquote':
-      return element('blockquote', block, void 0, toHastChildren(block));
+      let attr: hast.IElement['properties'] = void 0;
+      if (block.spoiler) attr = {'data-spoiler': 'true'};
+      return element('blockquote', block, attr, toHastChildren(block));
     case 'list': {
       const children = block.children;
       const length = children.length;

--- a/src/markdown/block/toHast.ts
+++ b/src/markdown/block/toHast.ts
@@ -69,10 +69,11 @@ export const toHast = (node: IToken | IToken[]): hast.THtmlToken => {
     }
     case 'heading':
       return element('h' + block.depth, block, void 0, toTextChildrenInline(block));
-    case 'blockquote':
+    case 'blockquote': {
       let attr: hast.IElement['properties'] = void 0;
       if (block.spoiler) attr = {'data-spoiler': 'true'};
       return element('blockquote', block, attr, toHastChildren(block));
+    }
     case 'list': {
       const children = block.children;
       const length = children.length;

--- a/src/markdown/block/toText.ts
+++ b/src/markdown/block/toText.ts
@@ -35,7 +35,8 @@ export const toText = (node: IToken | IToken[]): string => {
       return prefix + ' ' + toTextInlineChildren(block.children);
     }
     case 'blockquote': {
-      return '> ' + toTextBlockChildren(block.children).replace(/\n/g, '\n> ');
+      const indent = block.spoiler ? '>! ' : '> ';
+      return indent + toTextBlockChildren(block.children).replace(/\n/g, '\n' + indent);
     }
     case 'list': {
       const {ordered, start, spread} = block;

--- a/src/markdown/block/types.ts
+++ b/src/markdown/block/types.ts
@@ -54,6 +54,7 @@ export interface IHeading extends IToken {
 
 export interface IBlockquote extends IToken {
   type: 'blockquote';
+  spoiler?: boolean;
   children: TBlockToken[];
 }
 


### PR DESCRIPTION
Introduces support for StacOverlow-like block spoiler elements. They work like a blockquote, where each line contains `>!` in the beginning.

```
>! This is
>! 
>! spoiler...
```

Closes https://github.com/streamich/very-small-parser/issues/18

