### PR TITLE
fix(html): void elements should not consume sibling content

### DIFF
--- a/src/html/__tests__/parsers.spec.ts
+++ b/src/html/__tests__/parsers.spec.ts
@@ -277,6 +277,70 @@ describe('parsers', () => {
         });
       });
     });
+
+    describe('void elements without self-closing syntax', () => {
+      test('<br> without slash has no children', () => {
+        const ast = parse('1<br>2');
+        expect(ast).toMatchObject([
+          {type: 'text', value: '1'},
+          {
+            type: 'element',
+            tagName: 'br',
+            children: [],
+          },
+          {type: 'text', value: '2'},
+        ]);
+      });
+
+      test('<br> nested in <p> does not consume next sibling', () => {
+        const ast = parse('<p>1<br>2</p>');
+        expect(ast[0]).toMatchObject({
+          type: 'element',
+          tagName: 'p',
+          children: [
+            {type: 'text', value: '1'},
+            {
+              type: 'element',
+              tagName: 'br',
+              children: [],
+            },
+            {type: 'text', value: '2'},
+          ],
+        });
+      });
+
+      test('<img> without slash does not consume next sibling', () => {
+        const ast = parse('<p><img src="x">text</p>');
+        expect(ast[0]).toMatchObject({
+          type: 'element',
+          tagName: 'p',
+          children: [
+            {
+              type: 'element',
+              tagName: 'img',
+              children: [],
+            },
+            {type: 'text', value: 'text'},
+          ],
+        });
+      });
+
+      test('<hr> without slash is treated as void', () => {
+        const ast = parse('<div><hr>text</div>');
+        expect(ast[0]).toMatchObject({
+          type: 'element',
+          tagName: 'div',
+          children: [
+            {
+              type: 'element',
+              tagName: 'hr',
+              children: [],
+            },
+            {type: 'text', value: 'text'},
+          ],
+        });
+      });
+    });
   });
 
   describe('fragment', () => {

--- a/src/html/parsers.ts
+++ b/src/html/parsers.ts
@@ -39,6 +39,27 @@ const REG_ATTR = / +[a-zA-Z:_][\w.:-]*(?: *= *"[^"\n]*"| *= *'[^'\n]*'| *= *[^\s
 const REG_OPEN_TAG = reg.replace(/^<([a-z][\w-]*)(?:attr)*? *(\/?)>/, {attr: REG_ATTR});
 const REG_ATTRS = /([\w|data-]+)=["']?((?:.(?!["']?\s+(?:\S+)=|\s*\/?[>"']))*.)["']?/gm;
 const REG_CLOSE_TAG = /^<\/([a-z][\w-]*)>/;
+const isVoidElement = (tagName: string): boolean => {
+  switch (tagName) {
+    case 'area':
+    case 'base':
+    case 'br':
+    case 'col':
+    case 'embed':
+    case 'hr':
+    case 'img':
+    case 'input':
+    case 'link':
+    case 'meta':
+    case 'param':
+    case 'source':
+    case 'track':
+    case 'wbr':
+      return true;
+    default:
+      return false;
+  }
+};
 export const el: TTokenizer<type.IElement, HtmlParser> = (parser, src) => {
   const matchOpen = src.match(REG_OPEN_TAG);
   if (!matchOpen) return;
@@ -57,17 +78,13 @@ export const el: TTokenizer<type.IElement, HtmlParser> = (parser, src) => {
     children: [],
     len: matchLength,
   };
-  if (!selfClosing) {
+  if (!selfClosing && !isVoidElement(tagName)) {
     const substr = src.slice(matchLength);
     const fragment = parser.parsef(substr);
     const fragmentLen = fragment.len;
-    if (selfClosing) {
-      token.len! += fragment.len!;
-    } else {
-      const matchClose = substr.slice(fragmentLen).match(REG_CLOSE_TAG);
-      if (!matchClose) return token;
-      token.len! += fragment.len! + (matchClose?.[0].length ?? 0);
-    }
+    const matchClose = substr.slice(fragmentLen).match(REG_CLOSE_TAG);
+    if (!matchClose || matchClose[1] !== tagName) return token;
+    token.len! += fragmentLen! + (matchClose?.[0].length ?? 0);
     token.children = fragment.children as any;
   }
   return token;


### PR DESCRIPTION
Fixes #103

Added `isVoidElement()` check and close tag name validation in `src/html/parsers.ts`, plus 4 tests.